### PR TITLE
chore: add errors key for parseForESLint function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2021-10-20
+### Added
+- Add `errors` visitor key for `parseForESLint`
+
 ## [0.1.0] - 2021-10-19
 ### Added
 - Add more useful info on README.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxml/parser",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wxml/parser",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A fast and tolerant wxml parser",
   "type": "commonjs",
   "main": "lib/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,9 @@ function parseForESLint(code: string) {
     ast: buildAst(cst, tokenVector, lexErrors, parseErrors, true),
     services: {},
     scopeManager: null,
-    visitorKeys: null,
+    visitorKeys: {
+      Program: ["errors", "body"]
+    },
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ function parseForESLint(code: string) {
     services: {},
     scopeManager: null,
     visitorKeys: {
-      Program: ["errors", "body"]
+      Program: ["errors", "body"],
     },
   };
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: missing `errors` key for parseForESLint's visitorKeys

<!-- Why are these changes necessary? -->

**Why**: use to traverse wxml parse error

<!-- How were these changes implemented? -->

**How**: add "errors" key

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Unit Tests
- [ ] Code complete

<!-- feel free to add additional comments -->
