### PR TITLE
fix: wxinterpolation multiline support

### DIFF
--- a/src/cst/lexer.ts
+++ b/src/cst/lexer.ts
@@ -146,7 +146,7 @@ const wxmlLexerDefinition = {
       TEXT,
       MUSTACHE_LEFT,
     ],
-    INTPN_INSIDE: [MUSTACHE_RIGHT, INTPN, STRING],
+    INTPN_INSIDE: [MUSTACHE_RIGHT, INTPN, SEA_WS, STRING],
     INSIDE: [
       // Tokens from `OUTSIDE` to improve error recovery behavior
       COMMENT,

--- a/tests/error-spec.js
+++ b/tests/error-spec.js
@@ -201,8 +201,8 @@ describe("Error Test Suite", () => {
     // {{ nihao }}
     //          ↑↑
     const parseErrorMatchs = _.get(ast, 'errors') || [];
-    expect(parseErrorMatchs).to.be.lengthOf(3);
-    const parseError = parseErrorMatchs[2];
+    expect(parseErrorMatchs).to.be.lengthOf(1);
+    const parseError = parseErrorMatchs[0];
     expect(parseError).to.have.property("rawType");
     expect(parseError.rawType).to.be.equals("MismatchedTokenException");
     expect(parseError).to.have.property("value");

--- a/tests/interpolation-spec.js
+++ b/tests/interpolation-spec.js
@@ -139,4 +139,18 @@ describe("Interpolation Test Suite", () => {
   // <template is="objectCombine" data="{{...obj1, ...obj2, e: 5}}"></template>
   // <view wx:for="{{[1,2,3]}} ">
 
+  // #12 multi line
+  it("can parse WXInterpolation - multi line", () => {
+    const ast = parse(`
+       <view>
+        {{ OPTIONAL.default === type
+           ? "xiaomi"
+           : "meizu" }}
+      </view>
+    `);
+    expect(ast.errors).to.be.lengthOf(0);
+    const matches = esquery(ast, "WXInterpolation");
+    expect(matches).to.be.lengthOf(1);
+  })
+
 });


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

fix multiline `wxinterpolation` parse error

<!-- Why are these changes necessary? -->

**Why**:

```html
 <view>
  {{ OPTIONAL.default === type
     ? "xiaomi"
     : "meizu" }}
</view>
```

These lines code is valid, but @wxml/parser parse failed

<!-- How were these changes implemented? -->

**How**:

missing `SEA_WS` in  `INTPN_INSIDE`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Unit Tests
- [x] Code complete

<!-- feel free to add additional comments -->
