### PR TITLE
fix: add missing name property for wxscript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -824,9 +824,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true
     },
     "randombytes": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
     "mocha": "^9.1.3",
-    "prettier": "^2.4.1",
+    "prettier": "^2.5.1",
     "rollup": "^2.58.0",
     "tslib": "^2.3.1",
     "typescript": "^4.4.3"

--- a/src/ast/build-ast.ts
+++ b/src/ast/build-ast.ts
@@ -57,6 +57,7 @@ class CstToAstVisitor extends BaseWxmlCstVisitor {
     // process wxs inline js string first
     const astNode = {
       type: "WXScript",
+      name: "wxs",
       value: null,
       startTag: null,
       endTag: null,

--- a/tests/wxs-spec.js
+++ b/tests/wxs-spec.js
@@ -113,4 +113,14 @@ describe('WXS Test Suite', () => {
     expect(matchs[2].value.replace(/( |\t|\n|\r\n)+/, "")).to.be.equals("");
   });
 
+  it("WXSxript node should contain `name` property", () => {
+    const ast = parse(`
+      <wxs> var s = 22; </wxs>
+    `)
+
+    expect(ast.errors.length).to.be.equals(0);
+    const matchs = esquery(ast, "WXScript");
+    expect(matchs[0].name).to.be.equals("wxs");
+  });
+
 })


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

add `name` property for `WXScript` node && bump prettier

<!-- Why are these changes necessary? -->

**Why**:

same structure with othe ast node

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Unit Tests
- [x] Code complete

<!-- feel free to add additional comments -->
